### PR TITLE
Fix for downloading large files

### DIFF
--- a/ckanext/s3filestore/controller.py
+++ b/ckanext/s3filestore/controller.py
@@ -65,7 +65,8 @@ class S3Controller(base.BaseController):
                 client = s3.client(service_name='s3', endpoint_url=host_name)
                 url = client.generate_presigned_url(ClientMethod='get_object',
                                                     Params={'Bucket': bucket.name,
-                                                            'Key': key_path})
+                                                            'Key': key_path},
+                                                    ExpiresIn=60)
                 redirect(url)
 
             except ClientError as ex:

--- a/ckanext/s3filestore/controller.py
+++ b/ckanext/s3filestore/controller.py
@@ -8,7 +8,7 @@ import ckan.logic as logic
 import ckan.lib.base as base
 import ckan.model as model
 import ckan.lib.uploader as uploader
-from ckan.common import _, request, c, response, streaming_response
+from ckan.common import _, request, c, response
 from botocore.exceptions import ClientError
 
 from ckanext.s3filestore.uploader import S3Uploader

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -39,15 +39,19 @@ class BaseS3Uploader(object):
         directory = os.path.join(storage_path, id)
         return directory
 
+    def get_s3_session(self):
+        return boto3.session.Session(aws_access_key_id=self.p_key,
+                                     aws_secret_access_key=self.s_key,
+                                     region_name=self.region)
+
     def get_s3_bucket(self, bucket_name):
         '''Return a boto bucket, creating it if it doesn't exist.'''
 
         # make s3 connection using boto3
-        session = boto3.session.Session(aws_access_key_id=self.p_key,
-                                        aws_secret_access_key=self.s_key,
-                                        region_name=self.region)
-        s3 = session.resource('s3', endpoint_url=self.host_name,
-                              config=botocore.client.Config(signature_version=self.signature))
+
+        s3 = self.get_s3_session().resource('s3', endpoint_url=self.host_name,
+                                            config=botocore.client.Config(
+                                             signature_version=self.signature))
         bucket = s3.Bucket(bucket_name)
         try:
             if s3.Bucket(bucket.name) in s3.buckets.all():
@@ -55,7 +59,8 @@ class BaseS3Uploader(object):
 
             else:
                 log.warning(
-                    'Bucket {0} could not be found, attempting to create it...'.format(bucket_name))
+                    'Bucket {0} could not be found,\
+                    attempting to create it...'.format(bucket_name))
                 try:
                     bucket = s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={
                         'LocationConstraint': 'us-east-1'})


### PR DESCRIPTION
This is a workaround for downloading large files from Minio

Instead of downloading the data to application and then serving it via Pylons/Flask, we are redirecting to the Minio generated url for the resource
Expiration time for the URL is 3600 sec by default