### PR TITLE
Acl fix for non-resources

### DIFF
--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -245,8 +245,7 @@ class S3Uploader(BaseS3Uploader):
         # If a filename has been provided (a file is being uploaded) write the
         # file to the appropriate key in the AWS bucket.
         if self.filename:
-            self.upload_to_key(self.filepath, self.upload_file,
-                               make_public=True)
+            self.upload_to_key(self.filepath, self.upload_file)
             self.clear = True
 
         if (self.clear and self.old_filename


### PR DESCRIPTION
Currently, resources defer to the acl provided in the config `ckanext.s3filestore.acl`. Non resource items, such as organization logos, were forced to the public acl by the make public flag on upload to key. 

This fails for any bucket with Amazons default protections against public items. 

This fixes that, so that organization logos can be uploaded. 