### PR TITLE
allow preview param for PDFs

### DIFF
--- a/ckanext/s3filestore/views/resource.py
+++ b/ckanext/s3filestore/views/resource.py
@@ -66,7 +66,7 @@ def resource_download(package_type, id, resource_id, filename=None):
                      .format(key_path, upload.bucket_name))
 
         try:
-            if rsc.get('mimetype') == 'text/html' and preview:
+            if preview:
                 url = upload.get_signed_url_to_key(key_path)
             else:
                 params = {


### PR DESCRIPTION
Sometimes it is useful for other filetypes to be served without the `Content-Disposition: attachment` header.

I've targetted this PR at the main branch for review but it would also be useful to backport this to the ckan-2.8 branch. Once reviewed I can submit a follow-on PR targetting the ckan-2.8 if you like.

Refs https://github.com/ckan/ckanext-pdfview/pull/42