### PR TITLE
improve mimetype detection

### DIFF
--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -324,10 +324,11 @@ class S3ResourceUploader(BaseS3Uploader):
             self.mimetype = resource.get('mimetype')
             if not self.mimetype:
                 try:
-                    # 512 bytes should be enough for a mimetype check
+                    # Pass 2048 bytes to ensure MS Office file types e.g: XLSX
+                    # are not classified as application/zip
                     self.mimetype = \
-                        resource['mimetype'] =\
-                        mime.from_buffer(self.upload_file.read(512))
+                        resource['mimetype'] = \
+                        mime.from_buffer(self.upload_file.read(2048))
 
                     # additional check on text/plain mimetypes for
                     # more reliable result, if None continue with text/plain


### PR DESCRIPTION
We've been using this plugin on a CKAN install and we have been finding that MS office files (e.g: XLSX) are being detected as `application/zip`. Passing a larger chunk of buffer allows them to be correctly picked up as `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (or whatever)

I've targetted this PR at the main branch for review but it would also be useful to backport this to the ckan-2.8 branch. Once reviewed I can submit a follow-on PR targetting the ckan-2.8 if you like.