### PR TITLE
Cli upload group assets

### DIFF
--- a/ckanext/s3filestore/click_commands.py
+++ b/ckanext/s3filestore/click_commands.py
@@ -82,6 +82,7 @@ def upload_resources():
         fg=u'green',
         bold=True)
 
+
 @click.command(u's3-assets',
                short_help=u'Uploads all group assets '
                           u'from "ckan.storage_path"'
@@ -89,17 +90,18 @@ def upload_resources():
 def upload_assets():
     storage_path = config.get('ckan.storage_path',
                               '/var/lib/ckan/default/resources')
-    sqlalchemy_url = config.get('sqlalchemy.url',
-                                'postgresql://user:pass@localhost/db')
     bucket_name = config.get('ckanext.s3filestore.aws_bucket_name')
     acl = config.get('ckanext.s3filestore.acl', 'public-read')
     group_ids_and_paths = {}
     for root, dirs, files in os.walk(storage_path):
-        if root[-5:]=='group':
+        if root[-5:] == 'group':
             for idx, group_file in enumerate(files):
-                group_ids_and_paths[group_file]=os.path.join(root, files[idx])
-
-    click.secho('Found {0} resource files in the file system'.format(len(group_ids_and_paths)), fg=u'green', bold=True)
+                group_ids_and_paths[group_file] = os.path.join(
+                    root, files[idx])
+    click.secho('Found {0} resource files in the file system'.format(
+        len(group_ids_and_paths)),
+        fg=u'green',
+        bold=True)
 
     click.secho('{0} group assets found in the database'.format(
         len(group_ids_and_paths.keys())),
@@ -111,9 +113,15 @@ def upload_assets():
 
     uploaded_resources = []
     for resource_id, file_name in group_ids_and_paths.items():
-        key = 'storage/uploads/group/{resource_id}'.format(resource_id=resource_id)
-        s3_connection.Object(bucket_name, key).put(Body=open(file_name, u'rb'), ACL=acl)
+        key = 'storage/uploads/group/{resource_id}'.format(
+            resource_id=resource_id)
+        s3_connection.Object(bucket_name, key).put(
+            Body=open(file_name, u'rb'), ACL=acl)
         uploaded_resources.append(resource_id)
-        click.secho( 'Uploaded resource {0} to S3'.format(file_name), fg=u'green', bold=True)
+        click.secho(
+            'Uploaded resource {0} to S3'.format(file_name),
+            fg=u'green', bold=True)
     
-    click.secho('Done, uploaded {0} resources to S3'.format(len(uploaded_resources)), fg=u'green', bold=True)
+    click.secho('Done, uploaded {0} resources to S3'.format(
+        len(uploaded_resources)),
+        fg=u'green', bold=True)

--- a/ckanext/s3filestore/click_commands.py
+++ b/ckanext/s3filestore/click_commands.py
@@ -7,18 +7,19 @@ from sqlalchemy.sql import text
 from ckantoolkit import config
 from ckanext.s3filestore.uploader import BaseS3Uploader
 
+storage_path = config.get('ckan.storage_path',
+                          '/var/lib/ckan/default/resources')
+sqlalchemy_url = config.get('sqlalchemy.url',
+                            'postgresql://user:pass@localhost/db')
+bucket_name = config.get('ckanext.s3filestore.aws_bucket_name')
+acl = config.get('ckanext.s3filestore.acl', 'public-read')
+
 
 @click.command(u's3-upload',
                short_help=u'Uploads all resources '
                           u'from "ckan.storage_path"'
                           u' to the configured s3 bucket')
 def upload_resources():
-    storage_path = config.get('ckan.storage_path',
-                              '/var/lib/ckan/default/resources')
-    sqlalchemy_url = config.get('sqlalchemy.url',
-                                'postgresql://user:pass@localhost/db')
-    bucket_name = config.get('ckanext.s3filestore.aws_bucket_name')
-    acl = config.get('ckanext.s3filestore.acl', 'public-read')
     resource_ids_and_paths = {}
 
     for root, dirs, files in os.walk(storage_path):
@@ -88,10 +89,6 @@ def upload_resources():
                           u'from "ckan.storage_path"'
                           u' to the configured s3 bucket')
 def upload_assets():
-    storage_path = config.get('ckan.storage_path',
-                              '/var/lib/ckan/default/resources')
-    bucket_name = config.get('ckanext.s3filestore.aws_bucket_name')
-    acl = config.get('ckanext.s3filestore.acl', 'public-read')
     group_ids_and_paths = {}
     for root, dirs, files in os.walk(storage_path):
         if root[-5:] == 'group':

--- a/ckanext/s3filestore/click_commands.py
+++ b/ckanext/s3filestore/click_commands.py
@@ -81,3 +81,42 @@ def upload_resources():
             len(uploaded_resources)),
         fg=u'green',
         bold=True)
+
+@click.command(u's3-assets',
+               short_help=u'Uploads all group assets '
+                          u'from "ckan.storage_path"'
+                          u' to the configured s3 bucket')
+def upload_assets():
+    storage_path = config.get('ckan.storage_path',
+                              '/var/lib/ckan/default/resources')
+    sqlalchemy_url = config.get('sqlalchemy.url',
+                                'postgresql://user:pass@localhost/db')
+    bucket_name = config.get('ckanext.s3filestore.aws_bucket_name')
+    acl = config.get('ckanext.s3filestore.acl', 'public-read')
+    group_ids_and_paths = {}
+    for root, dirs, files in os.walk(storage_path):
+        if root[-5:]=='group':
+            for idx, group_file in enumerate(files):
+                group_ids_and_paths[group_file]=os.path.join(root, files[idx])
+
+    click.secho('Found {0} resource files in the file system'.format(len(group_ids_and_paths)), fg=u'green', bold=True)
+        
+    engine = create_engine(sqlalchemy_url)
+    connection = engine.connect()
+
+    click.secho('{0} group assets found in the database'.format(
+        len(group_ids_and_paths.keys())),
+        fg=u'green',
+        bold=True)
+
+    uploader = BaseS3Uploader()
+    s3_connection = uploader.get_s3_resource()
+
+    uploaded_resources = []
+    for resource_id, file_name in group_ids_and_paths.items():
+        key = 'storage/uploads/group/{resource_id}'.format(resource_id=resource_id)
+        s3_connection.Object(bucket_name, key).put(Body=open(file_name, u'rb'))
+        uploaded_resources.append(resource_id)
+        click.secho( 'Uploaded resource {0} to S3'.format(file_name), fg=u'green', bold=True)
+    
+    click.secho('Done, uploaded {0} resources to S3'.format(len(uploaded_resources)), fg=u'green', bold=True)

--- a/ckanext/s3filestore/click_commands.py
+++ b/ckanext/s3filestore/click_commands.py
@@ -121,7 +121,6 @@ def upload_assets():
         click.secho(
             'Uploaded resource {0} to S3'.format(file_name),
             fg=u'green', bold=True)
-    
     click.secho('Done, uploaded {0} resources to S3'.format(
         len(uploaded_resources)),
         fg=u'green', bold=True)

--- a/ckanext/s3filestore/click_commands.py
+++ b/ckanext/s3filestore/click_commands.py
@@ -100,9 +100,6 @@ def upload_assets():
                 group_ids_and_paths[group_file]=os.path.join(root, files[idx])
 
     click.secho('Found {0} resource files in the file system'.format(len(group_ids_and_paths)), fg=u'green', bold=True)
-        
-    engine = create_engine(sqlalchemy_url)
-    connection = engine.connect()
 
     click.secho('{0} group assets found in the database'.format(
         len(group_ids_and_paths.keys())),

--- a/ckanext/s3filestore/click_commands.py
+++ b/ckanext/s3filestore/click_commands.py
@@ -115,7 +115,7 @@ def upload_assets():
     uploaded_resources = []
     for resource_id, file_name in group_ids_and_paths.items():
         key = 'storage/uploads/group/{resource_id}'.format(resource_id=resource_id)
-        s3_connection.Object(bucket_name, key).put(Body=open(file_name, u'rb'))
+        s3_connection.Object(bucket_name, key).put(Body=open(file_name, u'rb'), ACL=acl)
         uploaded_resources.append(resource_id)
         click.secho( 'Uploaded resource {0} to S3'.format(file_name), fg=u'green', bold=True)
     

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -4,7 +4,7 @@ import ckantoolkit as toolkit
 
 import ckanext.s3filestore.uploader
 from ckanext.s3filestore.views import resource, uploads
-from ckanext.s3filestore.click_commands import upload_resources
+from ckanext.s3filestore.click_commands import upload_resources, upload_assets
 
 
 class S3FileStorePlugin(plugins.SingletonPlugin):
@@ -71,4 +71,4 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
     # IClick
 
     def get_commands(self):
-        return [upload_resources]
+        return [upload_resources, upload_assets]


### PR DESCRIPTION
If group or organization is created without ckanext-s3filestore extension and later the extension is added, the group/organization pics are not found (throws 404 error n browser console). Adds a cli command for upload of the group/organization assets (pics) to S3.